### PR TITLE
Updates for Class Exercise 2017-08-11

### DIFF
--- a/ActorKit/Scripts/Actor.Common/Spawner.cs
+++ b/ActorKit/Scripts/Actor.Common/Spawner.cs
@@ -22,6 +22,10 @@ namespace Actor.Common {
             SetupAttachedGameObjectAsSpawnPoint();
         }
 
+        public void TriggerSpawn() {
+            SpawnCharacter();
+        }
+
         public GameObject SpawnCharacter() {
             GameObject CharacterInWorld = MakeMainCharacter();
             Transform CharacterTransform = CharacterInWorld.GetComponent<Transform>();

--- a/ActorKit/Scripts/Actor.Inputs/TouchListener.cs
+++ b/ActorKit/Scripts/Actor.Inputs/TouchListener.cs
@@ -17,7 +17,7 @@ namespace Actor.Inputs {
         void Start() {
         }
 
-        public void TouchEvent(float domainValue) {
+        public virtual void TouchEvent(float domainValue) {
             UiDebug.Log("TouchEvent [{0}]", domainValue);
             Debug.LogFormat("TouchEvent [{0}]", domainValue);
         }

--- a/ActorKit/Scripts/Actor.Inputs/TouchRegion.cs
+++ b/ActorKit/Scripts/Actor.Inputs/TouchRegion.cs
@@ -32,7 +32,7 @@ namespace Actor.Inputs {
 
         [SerializeField] private bool EnableMouseToSimulateTouch = false;
         [SerializeField] private Direction TouchDirection = Direction.Horizontal;
-        [SerializeField] private TouchListener[] TouchEventListeners = new TouchListener[0];
+        [SerializeField] private TouchRegionEvent TouchEventListeners;
         [SerializeField] private Camera TouchCamera;
 
         private Image _TouchRegion;
@@ -47,16 +47,15 @@ namespace Actor.Inputs {
         public bool IsReady {
             get {
                 return _TouchRegion != null && _TouchRect != null
-                && TouchEventListeners != null && TouchEventListeners.Length > 0
-                && TouchCamera != null
-                ;
+                    && TouchEventListeners.GetPersistentEventCount() > 0
+                    && TouchCamera != null
+                    ;
             }
         }
 
         private void FireTouchEvents(float domainValue) {
-            foreach (var listener in TouchEventListeners) {
-                listener.TouchEvent(domainValue);
-            }
+            TouchEventListeners.Invoke(domainValue);
+            UiDebug.Log("Fire event {0}", domainValue);
         }
 
         void IPointerEnterHandler.OnPointerEnter(PointerEventData eventData) {

--- a/ActorKit/Scripts/Actor.Inputs/TouchRegionEvent.cs
+++ b/ActorKit/Scripts/Actor.Inputs/TouchRegionEvent.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Actor.Inputs {
+
+    [Serializable]
+    public class TouchRegionEvent : UnityEvent<float> {
+    }
+
+}


### PR DESCRIPTION
# Improvements to Touch Event Handling
Updates that made integration of the class exercise either just work or much easier.
TouchRegion now has a special event class that makes it easier to pass a touch event with the corresponding value to all registered listeners.

The TouchEventLister (component / monobehaviour) is basically defunct and the virtual method should just be made into a candidate receiver of a TouchRegionEvent.  It becomes a demo-only component.