### PR TITLE
Main fix TouchRegion

### DIFF
--- a/ActorKit/Scripts/Actor.Inputs/ArcadeMotionListenerCannon.cs
+++ b/ActorKit/Scripts/Actor.Inputs/ArcadeMotionListenerCannon.cs
@@ -16,8 +16,6 @@ namespace Actor.Inputs {
     [RequireComponent(typeof(Rigidbody))]
     public class ArcadeMotionListenerCannon : MonoBehaviour {
 
-        [SerializeField] private float ForceFactor = 100f;
-
         private Rigidbody _RigidBody;
 
         void Start() {

--- a/ActorKit/Scripts/Actor.Inputs/TouchRegion.cs
+++ b/ActorKit/Scripts/Actor.Inputs/TouchRegion.cs
@@ -78,8 +78,10 @@ namespace Actor.Inputs {
         }
 
         private void HandleTouchLikeEvent(PointerEventData eventData) {
-            SetupScreenRect();
-            FireTouchEvents(TouchDomainValue(eventData));
+            if (IsTouchLikeEvent(eventData)) {
+                SetupScreenRect();
+                FireTouchEvents(TouchDomainValue(eventData));
+            }
         }
 
         private float TouchDomainValue(PointerEventData pointerData) {


### PR DESCRIPTION
- Fixed TouchRegion so it reported 0.0 to 1.0 domain values in the touch event.
- Removed a warning from the ArcadeMotionListenerCannon.cs

Now the ScreenRect is computed on each touch because during Start() the setup conditions are unstable.
Checking on each touch made the domain calculation reliable.