### PR TITLE
Added direct Gyro support

### DIFF
--- a/ActorKit/Docs/Actor.Common-Spawner.md
+++ b/ActorKit/Docs/Actor.Common-Spawner.md
@@ -1,0 +1,19 @@
+# Spawner Component
+
+## Purpose
+Makes the prefab, selected in the Inspector, spawn at the location of the GameObject
+that has the Spawner component.
+
+## Inspector Values
+| Setting | Purpose                          |
+|---------|----------------------------------|
+|Character Prefab To Spawn | A slot that takes a game object to use as a template or Prefab instance in the project assets |
+
+## Methods
+| Method | Description                          |
+|---------|----------------------------------|
+| `void TriggerSpawn()` | Causes the prefab to be instantiated. |
+| `GameObject SpawnCharacter()` | Makes the instance and returns it to the caller. |
+
+### Copyright
+(c) Copyright 2017 Warwick Molloy, may be used under MIT License terms.

--- a/ActorKit/Docs/Actor.Common.md
+++ b/ActorKit/Docs/Actor.Common.md
@@ -1,0 +1,15 @@
+# Namespace Actor.Common
+
+## Purpose
+Components in this namespace represent common or general features that may be
+of help.
+
+## Components
+| Component | Link                                          |
+|-----------|-----------------------------------------------|
+| Spawner   | [Spawn objects][1]                            |
+
+[1]: ./Actor.Common-Spawner.md
+
+### Copyright
+(c) Copyright 2017 Warwick Molloy, may be used under MIT License terms.

--- a/ActorKit/Docs/Actor.Environment-MoodLight.md
+++ b/ActorKit/Docs/Actor.Environment-MoodLight.md
@@ -1,0 +1,23 @@
+# MoodLight Component
+
+## Purpose
+When attached to a GameObject that has one of the Unity Light components, will
+allow switching to a new color, chosen randomly, from the array of colors configured
+in the Inspector.
+
+The `BlendToNextRandomColor()` method can be triggered using a Unity UI button
+or can be called from another script component.
+
+## Inspector Values
+| Setting | Purpose                          |
+|---------|----------------------------------|
+|Colors To Choose | An array of colors to randomly select. |
+|Blend Speed In Seconds | Time (seconds) blending from one color to the next. |
+
+## Methods
+| Method | Description                          |
+|---------|----------------------------------|
+| `void BlendToNextRandomColor()` | Causes the component to choose another color. |
+
+### Copyright
+(c) Copyright 2017 Warwick Molloy, may be used under MIT License terms.

--- a/ActorKit/Docs/Actor.Environment.md
+++ b/ActorKit/Docs/Actor.Environment.md
@@ -1,0 +1,14 @@
+# Namespace Actor.Environment
+
+## Purpose
+Represents mood-setting or environmental features.
+
+## Components
+| Component   | Link                                                       |
+|-------------|------------------------------------------------------------|
+| MoodLight   | [Light modifying component that changes color randomly][1] |
+
+[1]: ./Actor.Environment-MoodLight.md
+
+### Copyright
+(c) Copyright 2017 Warwick Molloy, may be used under MIT License terms.

--- a/ActorKit/Docs/Actor.Events-DeviceMotionEvent.md
+++ b/ActorKit/Docs/Actor.Events-DeviceMotionEvent.md
@@ -1,0 +1,20 @@
+# DeviceMotion Event
+
+## Purpose
+A UnityEvent customised to provide (x, y, z) rotation in Euler Angles as an
+event that can be registered via the inspector in components that are
+sources of such events.
+
+To work, like other UnityEvent types, this will require at least one GameObject with an EventSystem component in the Scene.  EventSystems can be created from the Unity menu
+for GameObjects | UI | EventSystem.
+
+## Inspector Values
+| Setting | Purpose                          |
+|---------|----------------------------------|
+| Event | The event entry in the Inspector will have a `+` button that can be clicked to create a slot for a GameObject & Component|Function registration. |
+
+## Methods
+This class has no methods - see `UnityEngine.Events` namespace `UnityEvent` class for more information.
+
+### Copyright
+(c) Copyright 2017 Warwick Molloy, may be used under MIT License terms.

--- a/ActorKit/Docs/Actor.Events-MovePositionEvent.md
+++ b/ActorKit/Docs/Actor.Events-MovePositionEvent.md
@@ -1,0 +1,19 @@
+# MovePosition Event
+
+## Purpose
+A UnityEvent customised to provide (x, y, z) coordinates for a new position to be passed
+from an event source to an event listener.
+
+To work, like other UnityEvent types, this will require at least one GameObject with an EventSystem component in the Scene.  EventSystems can be created from the Unity menu
+for GameObjects | UI | EventSystem.
+
+## Inspector Values
+| Setting | Purpose                          |
+|---------|----------------------------------|
+| Event | The event entry in the Inspector will have a `+` button that can be clicked to create a slot for a GameObject & Component|Function registration. |
+
+## Methods
+This class has no methods - see `UnityEngine.Events` namespace `UnityEvent` class for more information.
+
+### Copyright
+(c) Copyright 2017 Warwick Molloy, may be used under MIT License terms.

--- a/ActorKit/Docs/Actor.Events-RelativeInputEvent.md
+++ b/ActorKit/Docs/Actor.Events-RelativeInputEvent.md
@@ -1,0 +1,30 @@
+# RelativeInput Event
+
+## Purpose
+A RelativeInputEvent passes a value between 0 and 1 for positive-range or -1 to 0 to +1 for full range. The event is sent from a relative input source to a relative input consumer.
+The consumer will determine what the relative input means - say a distance between two points
+or progress along a way point track.
+
+To work, like other UnityEvent types, this will require at least one GameObject with an EventSystem component in the Scene.  EventSystems can be created from the Unity menu
+for GameObjects | UI | EventSystem.
+
+## Inspector Values
+| Setting | Purpose                          |
+|---------|----------------------------------|
+| Event | The event entry in the Inspector will have a `+` button that can be clicked to create a slot for a GameObject & Component|Function registration. |
+
+## Methods
+No specialized instance methods are provided.
+
+## Static Methods
+| Method | Description                          |
+|---------|----------------------------------|
+| `static float WithinFullRange(float value)` | Normalizes the value to be within -1 to +1. |
+| `static float WithinPositiveRange(float value)` | Normalizes the value to be within 0 to 1 |
+
+The normalizing approach guarantees the values are within range by returning the original
+value if within the range and otherwise returning the closes extreme of the range - that is for
+a value of -2, -1 will be returned (also for anything less than -1) and an argument of 3 will return 1 (again any argument > 1 will return 1).
+
+### Copyright
+(c) Copyright 2017 Warwick Molloy, may be used under MIT License terms.

--- a/ActorKit/Docs/Actor.Events.md
+++ b/ActorKit/Docs/Actor.Events.md
@@ -1,0 +1,18 @@
+# Namespace Actor.Events
+
+## Purpose
+Event types and event sources are found in this namespace.
+
+## Components
+| Component | Link                                                     |
+|-------------------|--------------------------------------------------|
+| DeviceMotionEvent | [A Unity Event with Vector3 for Euler Angles][1] |
+| MovePositionEvent |    [Unity Event passing Vector3 for position][2] |
+| RelativeInputEvent| [Unity Event passing float for -1..1 or 0..1][3] |
+
+[1]: ./Actor.Events-DeviceMotionEvent.md
+[2]: ./Actor.Events-MovePositionEvent.md
+[3]: ./Actor.Events-RelativeInputEvent.md
+
+### Copyright
+(c) Copyright 2017 Warwick Molloy, may be used under MIT License terms.

--- a/ActorKit/Scripts/Actor.Events/GyroEvent.cs
+++ b/ActorKit/Scripts/Actor.Events/GyroEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+using UnityEngine.Events;
+
+namespace Actor.Events {
+
+    [Serializable]
+    public class GyroEvent : UnityEvent<Quaternion> {
+    }
+
+}

--- a/ActorKit/Scripts/Actor.Events/RotationEvent.cs
+++ b/ActorKit/Scripts/Actor.Events/RotationEvent.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * MovePositionEvent Unity Component
+ * RotationEvent Unity Component
  * (c) Copyright 2017, Warwick Molloy
  * GitHub repo WazzaMo/UnityComponents
  * Provided under the terms of the MIT License.
@@ -12,6 +12,6 @@ using UnityEngine.Events;
 namespace Actor.Events {
 
     [Serializable]
-    public class MovePositionEvent : UnityEvent<Vector3> {}
+    public class RotationEvent : UnityEvent<Quaternion> {}
 
 }

--- a/ActorKit/Scripts/Actor.Inputs/DebugRelativeListener.cs
+++ b/ActorKit/Scripts/Actor.Inputs/DebugRelativeListener.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * DeviceMotionListener Unity Component
+ * DebugRelativeListener Unity Component
  * (c) Copyright 2017, Warwick Molloy
  * GitHub repo WazzaMo/UnityComponents
  * Provided under the terms of the MIT License.
@@ -17,9 +17,9 @@ using Tools.Common;
 namespace Actor.Inputs {
 
 
-    public class DeviceMotionListener : MonoBehaviour {
-        public void MotionUpdateWithDownDirection(Vector3 DownDirection) {
-            UiDebug.Log("New downward direction {0}", DownDirection);
+    public class DebugRelativeListener : MonoBehaviour {
+        public void RelativeInputEvent(float value) {
+            UiDebug.Log("Debug Relative Input: {0}", value);
         }
     }
 

--- a/ActorKit/Scripts/Actor.Inputs/DeviceMotionKeyboardSim.cs
+++ b/ActorKit/Scripts/Actor.Inputs/DeviceMotionKeyboardSim.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 namespace Actor.Inputs {
 
     [Serializable]
-    public class DeviceMotionKeyboardSim {
+    public class DeviceMotionKeyboardSim : IDeviceMotionSource {
 
         public KeyCode
             ROLL_CLOCK = KeyCode.RightArrow,
@@ -34,18 +34,35 @@ namespace Actor.Inputs {
         private float _PitchAngle;
         private float _YawAngle;
 
+        public bool IsHardwareAvailable { get { return IsDesktop(); } }
+
+        public bool IsConfiguredCorrectly { get { return true; } }
+
+        public void SetupSource() {
+            ResetAllState();
+        }
+
+        public string GetConfigurationMessage() {
+            if (IsConfiguredCorrectly) {
+                return "";
+            } else {
+                return "";
+            }
+        }
+
+        public Vector3 GetDeviceDirectionTowardGravity() {
+            SimulateAccelerometer();
+            return _Direction;
+        }
+
         internal DeviceMotionKeyboardSim() {
             ResetAllState();
         }
 
-        internal void SimulateAccelerometer() {
+        private void SimulateAccelerometer() {
             CheckResetKey();
             UpdateAngles();
             UpdateOrientation();
-        }
-
-        internal Vector3 GetSimulatedDirectionTowardGravity() {
-            return _Direction;
         }
 
         private void UpdateAngles() {
@@ -96,6 +113,17 @@ namespace Actor.Inputs {
             _RollAngle = 0;
             _PitchAngle = 0;
             _YawAngle = 0;
+        }
+
+        private bool IsDesktop() {
+            return
+                Application.platform == RuntimePlatform.OSXEditor
+                || Application.platform == RuntimePlatform.OSXPlayer
+                || Application.platform == RuntimePlatform.WindowsEditor
+                || Application.platform == RuntimePlatform.WindowsPlayer
+                || Application.platform == RuntimePlatform.LinuxEditor
+                || Application.platform == RuntimePlatform.LinuxPlayer
+                ;
         }
     }
 

--- a/ActorKit/Scripts/Actor.Inputs/DeviceMotionSourceAccelGyro.cs
+++ b/ActorKit/Scripts/Actor.Inputs/DeviceMotionSourceAccelGyro.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * DeviceMotion Unity Component
+ * (c) Copyright 2017, Warwick Molloy
+ * GitHub repo WazzaMo/UnityComponents
+ * Provided under the terms of the MIT License.
+ */
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace Actor.Inputs {
+
+    public class DeviceMotionSourceAccelGyro : IDeviceMotionSource {
+        [SerializeField] private Vector3 SensitivityFactor = Vector3.one;
+
+        private bool _HasGyro;
+
+        public bool IsHardwareAvailable { get { return IsDeviceWithHardware(); } }
+
+        public bool IsConfiguredCorrectly { get { return true; } }
+
+        public void SetupSource() {
+            try {
+                _HasGyro = true;
+                Input.gyro.enabled = true;
+            } catch(Exception) {
+                _HasGyro = false;
+            }
+        }
+
+        public Vector3 GetDeviceDirectionTowardGravity() {
+            Vector3 toGravity;
+            if (_HasGyro) {
+                toGravity = Vector3.Normalize(ReadAccelerometer() + ReadGyro());
+            } else {
+                toGravity = ReadAccelerometer();
+            }
+            return toGravity;
+        }
+
+        public string GetConfigurationMessage() {
+            if (IsConfiguredCorrectly) {
+                return "";
+            } else {
+                return "";
+            }
+        }
+
+        internal DeviceMotionSourceAccelGyro() { }
+
+        private Vector3 ReadGyro() {
+            return AdjustGyro(Input.gyro.attitude) * Vector3.down;
+        }
+
+        private Quaternion AdjustGyro(Quaternion gyroRotation) {
+            return new Quaternion(gyroRotation.x, gyroRotation.y, -gyroRotation.z, -gyroRotation.w);
+        }
+
+        private Vector3 ReadAccelerometer() {
+            AccelerationEvent accelEvent;
+            Vector3 sumRotations = Vector3.zero;
+            Vector3 direction;
+
+            for (int index = 0; index < Input.accelerationEventCount; index++) {
+                accelEvent = Input.accelerationEvents[index];
+                sumRotations += accelEvent.deltaTime * accelEvent.acceleration;
+            }
+            direction.y = sumRotations.y;
+            direction.x = sumRotations.x;
+            direction.z = sumRotations.z;
+            direction.Normalize();
+            return direction;
+        }
+
+        private bool IsDeviceWithHardware() {
+            return Application.isMobilePlatform
+                || Application.platform == RuntimePlatform.Android
+                || Application.platform == RuntimePlatform.IPhonePlayer
+                || Application.platform == RuntimePlatform.TizenPlayer
+                ;
+        }
+    }
+
+}

--- a/ActorKit/Scripts/Actor.Inputs/DeviceMotionToRelativeInput.cs
+++ b/ActorKit/Scripts/Actor.Inputs/DeviceMotionToRelativeInput.cs
@@ -36,9 +36,11 @@ namespace Actor.Inputs {
                 HandleRoll(towardGravity);
             }
             if (HasPitchHandler) {
+                Debug.LogFormat("Pitch {0}", towardGravity);
                 HandlePitch(towardGravity);
             }
             if (HasYawHandler) {
+                Debug.LogFormat("Yaw {0}", towardGravity);
                 HandleYaw(towardGravity);
             }
         }

--- a/ActorKit/Scripts/Actor.Inputs/GyroHardwareReader.cs
+++ b/ActorKit/Scripts/Actor.Inputs/GyroHardwareReader.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * GyroHardwareReader
+ * (c) Copyright 2017, Warwick Molloy
+ * GitHub repo WazzaMo/UnityComponents
+ * Provided under the terms of the MIT License.
+ */
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using UnityEngine;
+
+namespace Actor.Inputs {
+
+    public class GyroHardwareReader : IGyroReader {
+        private static readonly Vector3 _ViewDirection = Vector3.back;
+
+        public GyroHardwareReader() {
+            Input.gyro.enabled = true;
+        }
+
+        public Quaternion TakeOrientationReading() {
+            return FromDownToForward(GyroToUnity(Input.gyro.attitude));
+        }
+
+        private static Quaternion GyroToUnity(Quaternion q) {
+            return new Quaternion(q.x, q.y, -q.z, -q.w);
+        }
+
+        private Quaternion FromDownToForward(Quaternion qIn) {
+            var adjustment = Quaternion.FromToRotation(Vector3.down, _ViewDirection);
+            return adjustment * qIn;
+        }
+
+    }
+
+}

--- a/ActorKit/Scripts/Actor.Inputs/GyroSimulatedReader.cs
+++ b/ActorKit/Scripts/Actor.Inputs/GyroSimulatedReader.cs
@@ -1,0 +1,117 @@
+﻿/*
+ * GyroSimulatedReader
+ * (c) Copyright 2017, Warwick Molloy
+ * GitHub repo WazzaMo/UnityComponents
+ * Provided under the terms of the MIT License.
+ */
+
+using System;
+
+using UnityEngine;
+
+namespace Actor.Inputs {
+
+    [Serializable]
+    public class AxisConfig {
+        public KeyCode Clockwise;
+        public KeyCode Anticlockwise;
+    }
+
+    [Serializable]
+    public class GyroSimConfig {
+        public AxisConfig XAxis;
+        public AxisConfig YAxis;
+        public AxisConfig ZAxis;
+    }
+
+    public class GyroSimulatedReader : IGyroReader {
+        const float ANGLE_EXTENT = 180f;
+
+        private GyroSimConfig _Config;
+        private AxisSim _X;
+        private AxisSim _Y;
+        private AxisSim _Z;
+
+        public GyroSimulatedReader(GyroSimConfig config) {
+            _Config = config;
+            _X = new AxisSim(_Config.XAxis);
+            _Y = new AxisSim(_Config.YAxis);
+            _Z = new AxisSim(_Config.ZAxis);
+        }
+
+        public Quaternion TakeOrientationReading() {
+            float x, y, z;
+            x = _X.TakeReading() * ANGLE_EXTENT;
+            y = _Y.TakeReading() * ANGLE_EXTENT;
+            z = _Z.TakeReading() * ANGLE_EXTENT;
+            return Quaternion.Euler(x, y, z);
+        }
+
+        internal class AxisSim {
+            const float
+                FALLING_RATIO = 0.9f,
+                INCREMENT = 0.05f,
+                MAXVALUE = 1f,
+                MINVALUE = 0.01f;
+
+            enum KeyState {
+                Released,
+                Pressed
+            }
+
+            private float _Value;
+            private AxisConfig _Config;
+            private KeyState _ClockwiseState;
+            private KeyState _AnticlockwiseState;
+
+            internal AxisSim(AxisConfig config) {
+                _Value = 0f;
+                _Config = config;
+                _ClockwiseState = KeyState.Released;
+                _AnticlockwiseState = KeyState.Released;
+            }
+
+            public float TakeReading() {
+                UpdateAxis();
+                return _Value;
+            }
+
+            private void UpdateAxis() {
+                UpdateKeyState();
+                if (IsNonePressed()) {
+                    _Value = 0.9f * _Value;
+                } else if (IsClockwise()) {
+                    _Value += INCREMENT;
+                } else if (IsAnticlockwise()) {
+                    _Value -= INCREMENT;
+                }
+                if (_Value > MAXVALUE) _Value = MAXVALUE;
+                else if (_Value < -MAXVALUE) _Value = -MAXVALUE;
+                else if (Mathf.Abs(_Value) < MINVALUE) _Value = 0f;
+            }
+
+            private bool IsNonePressed() { return _ClockwiseState == KeyState.Released && _AnticlockwiseState == KeyState.Released; }
+            private bool IsClockwise() { return _ClockwiseState == KeyState.Pressed && _AnticlockwiseState != KeyState.Pressed; }
+            private bool IsAnticlockwise() { return _AnticlockwiseState == KeyState.Pressed && _ClockwiseState != KeyState.Pressed; }
+
+            private void UpdateKeyState() {
+                KeyState? maybeState;
+                maybeState = GetState(_Config.Clockwise);
+                _ClockwiseState = maybeState != null ? (KeyState)maybeState : _ClockwiseState;
+
+                maybeState = GetState(_Config.Anticlockwise);
+                _AnticlockwiseState = maybeState != null ? (KeyState)maybeState : _AnticlockwiseState;
+            }
+
+            private KeyState? GetState(KeyCode code) {
+                if (Input.GetKeyDown(code)) {
+                    return KeyState.Pressed;
+                } else if (Input.GetKeyUp(code)) {
+                    return KeyState.Released;
+                }
+                return null;
+            }
+        }
+    }
+
+}

--- a/ActorKit/Scripts/Actor.Inputs/GyroTracking.cs
+++ b/ActorKit/Scripts/Actor.Inputs/GyroTracking.cs
@@ -1,0 +1,81 @@
+﻿/*
+ * GyroTracking Unity Component
+ * (c) Copyright 2017, Warwick Molloy
+ * GitHub repo WazzaMo/UnityComponents
+ * Provided under the terms of the MIT License.
+ */
+
+
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+using Tools.Common;
+
+using Actor.Events;
+
+namespace Actor.Inputs {
+
+    public class GyroTracking : MonoBehaviour {
+        [Tooltip("For updates on Device Orientiation")]
+        [SerializeField] private GyroEvent GyroOrientationListeners;
+
+        [Header("Editor Simulation")]
+        [Tooltip("Use keyboard to simulate?")]
+        [SerializeField] private bool UseKeyBoardToGyro = true;
+
+        [Tooltip("Keyboard arrangement for simulation in Editor")]
+        [SerializeField]
+        private GyroSimConfig KeyConfiguration = new GyroSimConfig() {
+            XAxis = new AxisConfig() { Clockwise = KeyCode.DownArrow, Anticlockwise = KeyCode.UpArrow },
+            YAxis = new AxisConfig() { Clockwise = KeyCode.RightArrow, Anticlockwise = KeyCode.LeftArrow },
+            ZAxis = new AxisConfig() { Clockwise = KeyCode.A, Anticlockwise = KeyCode.Z }
+        };
+
+        private IGyroReader _GyroReader;
+
+        public GyroEvent GyroListeners { get { return GyroOrientationListeners; } }
+        public bool IsReady { get { return _GyroReader != null; } }
+
+        void Start() {
+            SetupTrackingSources();
+            if (HasListeners) {
+                Debug.Log("GyroTracking has associated listeners.");
+            } else {
+                Debug.LogWarning("No listeners associated with GyroTracking.");
+            }
+        }
+
+        void Update() {
+            if ( HasListeners && IsReady ){
+                Quaternion value = TakeReading();
+                NotifyListeners(value);
+            }
+        }
+
+        private bool HasListeners {
+            get { return GyroOrientationListeners.GetPersistentEventCount() > 0; }
+        }
+
+        private Quaternion TakeReading() {
+            return _GyroReader.TakeOrientationReading();
+        }
+
+        private void NotifyListeners(Quaternion value) {
+            GyroOrientationListeners.Invoke(value);
+        }
+
+        private void SetupTrackingSources() {
+            if (Application.isMobilePlatform) {
+                _GyroReader = new GyroHardwareReader();
+            } else if (UseKeyBoardToGyro) {
+                _GyroReader = new GyroSimulatedReader(KeyConfiguration);
+                Debug.Log("GyroTracking configured for Keyboard input");
+            } else {
+                _GyroReader = null;
+                Debug.Log("GyroTracking not configured for input!");
+            }
+        }
+    }
+
+}

--- a/ActorKit/Scripts/Actor.Inputs/IDeviceMotionSource.cs
+++ b/ActorKit/Scripts/Actor.Inputs/IDeviceMotionSource.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * DeviceMotion Unity Component
+ * (c) Copyright 2017, Warwick Molloy
+ * GitHub repo WazzaMo/UnityComponents
+ * Provided under the terms of the MIT License.
+ * 
+ * An internal contract for how motion sources should work
+ * within the DeviceMotion Unity component.
+ */
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using UnityEngine;
+
+namespace Actor.Inputs {
+
+    public interface IDeviceMotionSource {
+        bool IsHardwareAvailable { get; }
+        bool IsConfiguredCorrectly { get; }
+
+        string GetConfigurationMessage();
+        void SetupSource();
+        Vector3 GetDeviceDirectionTowardGravity();
+    }
+
+}

--- a/ActorKit/Scripts/Actor.Inputs/IGyroReader.cs
+++ b/ActorKit/Scripts/Actor.Inputs/IGyroReader.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+using UnityEngine;
+
+
+
+namespace Actor.Inputs {
+
+    public interface IGyroReader {
+        Quaternion TakeOrientationReading();
+    }
+
+}

--- a/ActorKit/Scripts/Actor.Relative/LookAtOther.cs
+++ b/ActorKit/Scripts/Actor.Relative/LookAtOther.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 namespace Actor.Relative {
 
     public class LookAtOther : MonoBehaviour {
-        [SerializeField] GameObject Other;
+        [SerializeField] GameObject Other = null;
 
         void Start() {
             Setup();

--- a/ActorKitExamples/Scenes/Accel01-DebugDevScene.unity
+++ b/ActorKitExamples/Scenes/Accel01-DebugDevScene.unity
@@ -368,7 +368,6 @@ GameObject:
   - component: {fileID: 510562335}
   - component: {fileID: 510562334}
   - component: {fileID: 510562333}
-  - component: {fileID: 510562332}
   - component: {fileID: 510562338}
   - component: {fileID: 510562337}
   m_Layer: 5
@@ -378,48 +377,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &510562332
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 510562331}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5a100f6f6af7ae648a3d7821dee906d0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ArcadeMotionListeners:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Actor.Events.DeviceMotionEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  RollRelativeListeners:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Actor.Events.RelativeInputEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  PitchRelativeListeners:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Actor.Events.RelativeInputEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  YawRelativeListeners:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Actor.Events.RelativeInputEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  SensitivityFactor: {x: 1, y: 1, z: 1}
-  UseKeyBoardToSimulateAccelerometer: 1
-  _MotionSimulator:
-    ROLL_CLOCK: 275
-    ROLL_ANTI: 276
-    PITCH_CLOCK: 273
-    PITCH_ANTI: 274
-    YAW_CLOCK: 122
-    YAW_ANTI: 120
-    RESET: 32
-    Increment: 5
 --- !u!23 &510562333
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -763,7 +720,6 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: Actor.Events.RelativeInputEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
-  SensitivityFactor: {x: 1, y: 1, z: 1}
   UseKeyBoardToSimulateAccelerometer: 1
   _MotionSimulator:
     ROLL_CLOCK: 275

--- a/ActorKitExamples/Scenes/DeviceMotionSample.unity
+++ b/ActorKitExamples/Scenes/DeviceMotionSample.unity
@@ -1,0 +1,1238 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 8
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 9
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &58835434
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 58835435}
+  - component: {fileID: 58835438}
+  - component: {fileID: 58835437}
+  - component: {fileID: 58835436}
+  m_Layer: 0
+  m_Name: Brick
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &58835435
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 58835434}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.3, z: 4.5}
+  m_LocalScale: {x: 0.6, y: 0.6, z: 0.3}
+  m_Children: []
+  m_Father: {fileID: 1202160662}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &58835436
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 58835434}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: fe9f9518e08174b4bb0b152668307449, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &58835437
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 58835434}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &58835438
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 58835434}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &262636888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 262636892}
+  - component: {fileID: 262636891}
+  - component: {fileID: 262636890}
+  - component: {fileID: 262636889}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &262636889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 262636888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &262636890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 262636888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &262636891
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 262636888}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &262636892
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 262636888}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &298835828
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 298835829}
+  m_Layer: 0
+  m_Name: CubeHandle-East
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &298835829
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 298835828}
+  m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2084056405}
+  m_Father: {fileID: 1772054651}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
+--- !u!1 &361957242
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 361957243}
+  m_Layer: 0
+  m_Name: CubeHandle-East
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &361957243
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 361957242}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2051556153}
+  m_Father: {fileID: 1772054651}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &393092426
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 393092429}
+  - component: {fileID: 393092427}
+  - component: {fileID: 393092428}
+  m_Layer: 0
+  m_Name: Dolly
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &393092427
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 393092426}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3819eeb298e80554b95d8142b6c9fd36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _Radius: 1
+  _TrackAngle: 360
+  _TrackOrientation: {x: -0.5, y: -0.5, z: -0.5, w: 0.5}
+  _FullRange: 1
+--- !u!114 &393092428
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 393092426}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 870750dac6217fe43a51a0db434a7fb7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackToFollow: {fileID: 1780541249}
+--- !u!4 &393092429
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 393092426}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -2, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1905292505}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &403704499
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 403704500}
+  - component: {fileID: 403704503}
+  - component: {fileID: 403704502}
+  - component: {fileID: 403704501}
+  m_Layer: 0
+  m_Name: Brick
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &403704500
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 403704499}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.3, z: 4.5}
+  m_LocalScale: {x: 0.6, y: 0.6, z: 0.3}
+  m_Children: []
+  m_Father: {fileID: 1668067977}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &403704501
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 403704499}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 14637363c29ce69409fc316bb6aa9275, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &403704502
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 403704499}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &403704503
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 403704499}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &467396392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 467396393}
+  - component: {fileID: 467396394}
+  - component: {fileID: 467396395}
+  m_Layer: 0
+  m_Name: DeviceMotion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &467396393
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 467396392}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &467396394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 467396392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a100f6f6af7ae648a3d7821dee906d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ArcadeMotionListeners:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Actor.Events.DeviceMotionEvent, Assembly-CSharp, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  RollRelativeListeners:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Actor.Events.RelativeInputEvent, Assembly-CSharp, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  PitchRelativeListeners:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 393092427}
+        m_MethodName: set_TrackAngle
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Actor.Events.RelativeInputEvent, Assembly-CSharp, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  YawRelativeListeners:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1780541249}
+        m_MethodName: set_TrackAngle
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 467396395}
+        m_MethodName: RelativeInputEvent
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Actor.Events.RelativeInputEvent, Assembly-CSharp, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  UseKeyBoardToSimulateAccelerometer: 1
+  _MotionSimulator:
+    ROLL_CLOCK: 275
+    ROLL_ANTI: 276
+    PITCH_CLOCK: 273
+    PITCH_ANTI: 274
+    YAW_CLOCK: 122
+    YAW_ANTI: 120
+    RESET: 32
+    Increment: 50
+--- !u!114 &467396395
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 467396392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60d1efd30ba81d74ba4aa26949a55a2c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &707788193
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 707788195}
+  - component: {fileID: 707788194}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &707788194
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 707788193}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &707788195
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 707788193}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &865104920
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 865104925}
+  - component: {fileID: 865104924}
+  - component: {fileID: 865104923}
+  - component: {fileID: 865104922}
+  - component: {fileID: 865104921}
+  - component: {fileID: 865104927}
+  - component: {fileID: 865104926}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &865104921
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 865104920}
+  m_Enabled: 1
+--- !u!124 &865104922
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 865104920}
+  m_Enabled: 1
+--- !u!92 &865104923
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 865104920}
+  m_Enabled: 1
+--- !u!20 &865104924
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 865104920}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!4 &865104925
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 865104920}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.34, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1905292505}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &865104926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 865104920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a657e4ef57f7794479983a4051d6d5e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Other: {fileID: 1905292504}
+--- !u!114 &865104927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 865104920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 870750dac6217fe43a51a0db434a7fb7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackToFollow: {fileID: 393092427}
+--- !u!1 &1193578654
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1193578657}
+  - component: {fileID: 1193578656}
+  - component: {fileID: 1193578655}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1193578655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1193578654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1193578656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1193578654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 467396392}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 5
+--- !u!4 &1193578657
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1193578654}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1202160661
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1202160662}
+  m_Layer: 0
+  m_Name: CubeHandle-South
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1202160662
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1202160661}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0000005, y: 1, z: 1.0000005}
+  m_Children:
+  - {fileID: 58835435}
+  m_Father: {fileID: 1772054651}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!1 &1668067976
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1668067977}
+  m_Layer: 0
+  m_Name: CubeHandle-North
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1668067977
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1668067976}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 403704500}
+  m_Father: {fileID: 1772054651}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1772054647
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1772054651}
+  - component: {fileID: 1772054650}
+  - component: {fileID: 1772054649}
+  - component: {fileID: 1772054648}
+  m_Layer: 0
+  m_Name: Plane-Ground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1772054648
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1772054647}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: d58155e75ea8d3f45b5e6b0dd00e6be1, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!64 &1772054649
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1772054647}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 0
+  m_InflateMesh: 0
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &1772054650
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1772054647}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1772054651
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1772054647}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_Children:
+  - {fileID: 1668067977}
+  - {fileID: 361957243}
+  - {fileID: 1202160662}
+  - {fileID: 298835829}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1780541248
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1780541250}
+  - component: {fileID: 1780541249}
+  m_Layer: 0
+  m_Name: Base
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1780541249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1780541248}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3819eeb298e80554b95d8142b6c9fd36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _Radius: 20
+  _TrackAngle: 360
+  _TrackOrientation: {x: 0, y: 0, z: 0, w: 1}
+  _FullRange: 1
+--- !u!4 &1780541250
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1780541248}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -2, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1905292505}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1905292504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1905292505}
+  m_Layer: 0
+  m_Name: Centre
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1905292505
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1905292504}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1780541250}
+  - {fileID: 393092429}
+  - {fileID: 865104925}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2051556152
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2051556153}
+  - component: {fileID: 2051556156}
+  - component: {fileID: 2051556155}
+  - component: {fileID: 2051556154}
+  m_Layer: 0
+  m_Name: Brick
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2051556153
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2051556152}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.3, z: 4.5}
+  m_LocalScale: {x: 0.6, y: 0.6, z: 0.3}
+  m_Children: []
+  m_Father: {fileID: 361957243}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &2051556154
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2051556152}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: eefac7aacf14b584ba4b3dca1ececeb2, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &2051556155
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2051556152}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &2051556156
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2051556152}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2084056404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2084056405}
+  - component: {fileID: 2084056408}
+  - component: {fileID: 2084056407}
+  - component: {fileID: 2084056406}
+  m_Layer: 0
+  m_Name: Brick
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2084056405
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2084056404}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.3, z: 4.5}
+  m_LocalScale: {x: 0.6, y: 0.6, z: 0.3}
+  m_Children: []
+  m_Father: {fileID: 298835829}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &2084056406
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2084056404}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: fced5b7698469b24fa97d290fbdd3739, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &2084056407
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2084056404}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &2084056408
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2084056404}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}

--- a/ActorKitExamples/Scenes/SimpleRollRelativeExample.unity
+++ b/ActorKitExamples/Scenes/SimpleRollRelativeExample.unity
@@ -456,7 +456,7 @@ MonoBehaviour:
   _Radius: 3.5
   _TrackAngle: 180
   _TrackOrientation: {x: 0, y: -0.707992, z: 0, w: 0.70622045}
-  _FullRange: 0
+  _FullRange: 1
 --- !u!114 &912722915
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Changes
- GyroEvent that reports a new device orientation (Quaternion)
- GyroTracking component that can be added to a camera to track device rotations
-- supports simulation in the Editor
-- works on Android and should (untested) work on iOS
- GyroHardwareReader class used by GyroTracking when compiled for a mobile device
- GyroSimulatedReader for Editor Play mode simulation (if enabled)
-- may be configured to use any 6 keys.
